### PR TITLE
Attachment filename support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ Known Limitations
 
   * Assumes encoding of texts is 'utf-8'...and there's no way to change it.
     
-  * Does not try to recover texts with photos.  Just skips past them.
-  
   * Does not handle group chats.
 
 License

--- a/sms-backup.py
+++ b/sms-backup.py
@@ -710,12 +710,13 @@ def msgs_csv(messages, header):
     queue = cStringIO.StringIO()
     writer = csv.writer(queue, dialect=csv.excel, quoting=csv.QUOTE_ALL)
     if header:
-        writer.writerow(['Date', 'From', 'To', 'Text'])
+        writer.writerow(['Date', 'From', 'To', 'Text', 'Filename'])
     for m in messages:
         writer.writerow([m['date'].encode('utf-8'),
                          m['from'].encode('utf-8'),
                          m['to'].encode('utf-8'),
-                         m['text'].encode('utf-8')])
+                         m['text'].encode('utf-8'),
+                         (m['filename'].encode('utf-8') if m['filename'] else '')])
     output = queue.getvalue()
     queue.close()
     return output

--- a/sms-backup.py
+++ b/sms-backup.py
@@ -31,7 +31,6 @@ import shutil
 import sqlite3
 import sys
 import tempfile
-import subprocess
 import hashlib
 import string
 


### PR DESCRIPTION
This PR adds support to look up any related attachments (photos, contacts, map pins, etc) to a message, and to include a path to the file in the final result under a `filename` key. 

This is the first Python I've written – I can't imagine this is great code. I'm just sticking it up here so somebody else might get some mileage out of it. The `replace` on `ORIG_DB` is particularly gross, and I'm sure I've done other things wrong as well. 

Sample result:

```
{
  "date": "2014-08-04 14:25:33", 
  "filename": "/Users/Andrew/Library/Application Support/MobileSync/Backup/[...]/69153a839cda555c05a8f25aed66c9817ba06822", 
  "from": "[...]", 
  "text": "￼I thought you might appreciate this lovely photo.", 
  "to": "Me"
},  
```

The `filename` points to a path on the local file system within the iOS backup that is a JPEG/PNG/VCard file.
